### PR TITLE
Adjust dependency finding so lib works better as submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ message(STATUS "Building xtensor-fftw v${${PROJECT_NAME}_VERSION}")
 
 #--------------------------------------- cmake modules
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/findFFTW/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/findFFTW/")
 
 #--------------------------------------- user options
 set(FFTW_ROOT "" CACHE STRING "The FFTW prefix, i.e. the base directory under which FFTW is installed (see README.md).")
@@ -67,15 +67,33 @@ include_directories(${XTENSOR_FFTW_INCLUDE_DIR})
 
 # .. xtensor
 set(xtensor_REQUIRED_VERSION 0.20.9)
-find_package(xtensor ${xtensor_REQUIRED_VERSION} REQUIRED)
-message(STATUS "Found xtensor: ${xtensor_INCLUDE_DIRS}/xtensor")
-include_directories(${xtensor_INCLUDE_DIRS})
+if(TARGET xtensor)
+    set(xtensor_VERSION ${XTENSOR_VERSION_MAJOR}.${XTENSOR_VERSION_MINOR}.${XTENSOR_VERSION_PATCH})
+    # Note: This is not SEMVER compatible comparison
+    if( NOT ${xtensor_VERSION} VERSION_GREATER_EQUAL ${xtensor_REQUIRED_VERSION})
+        message(ERROR "Mismatch xtensor versions. Found '${xtensor_VERSION}' but requires: '${xtensor_REQUIRED_VERSION}'")
+    else()
+        message(STATUS "Found xtensor v${xtensor_VERSION}")
+    endif()
+else()
+    find_package(xtensor ${xtensor_REQUIRED_VERSION} REQUIRED)
+    message(STATUS "Found xtensor: ${xtensor_INCLUDE_DIRS}/xtensor")
+endif()
 
 # .. xtl
 set(xtl_REQUIRED_VERSION 0.6.9)
-find_package(xtl ${xtl_REQUIRED_VERSION} REQUIRED)
-message(STATUS "Found xtl: ${xtl_INCLUDE_DIRS}/xtl")
-include_directories(${xtl_INCLUDE_DIRS})
+if(TARGET xtl)
+    set(xtl_VERSION ${XTL_VERSION_MAJOR}.${XTL_VERSION_MINOR}.${XTL_VERSION_PATCH})
+    # Note: This is not SEMVER compatible comparison
+    if( NOT ${xtl_VERSION} VERSION_GREATER_EQUAL ${xtl_REQUIRED_VERSION})
+        message(ERROR "Mismatch xtl versions. Found '${xtl_VERSION}' but requires: '${xtl_REQUIRED_VERSION}'")
+    else()
+        message(STATUS "Found xtl v${xtl_VERSION}")
+    endif()
+else()
+    find_package(xtl ${xtl_REQUIRED_VERSION} REQUIRED)
+    message(STATUS "Found xtl: ${xtl_INCLUDE_DIRS}/xtl")
+endif()
 
 # .. fftw
 if(MSVC)


### PR DESCRIPTION
When trying to use xtensor-fftw as a submodule, I encountered two errors. One, cmake did not recognize that I had defined the xtensor and xtl build targets already, because I have submoduled those repositories. Other projects in the xtensor-stack appear to support this, so I followed the same pattern. Secondly, when searching for libfftw, the code had a path to FindFFTW.cmake that does not necessarily work when this library is used in a submodule. I adjusted the path so that it works in both cases.

- Check for xtensor and xtl targets, similar to how xtensor-python does
it.
- Adjust path to FindFFTW.cmake so that it uses CMAKE_CURRENT_SOURCE_DIR
instead of CMAKE_SOURCE_DIR