### PR TITLE
Add support for xtensor 0.26 and upgrade CMake / GoogleTest dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -157,7 +157,7 @@ install:
     - export PATH="$HOME/miniconda/bin:$PATH"
     - hash -r
     - conda update -yq conda
-    - conda install -y cmake xtl==0.6.9 xtensor=0.21.2 nlohmann_json=3.7.1 -c conda-forge
+    - conda install -y cmake xtl=>0.8.0 xtensor=>0.26.0 nlohmann_json=3.7.1 -c conda-forge
     - |
       if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         conda install -y fftw -c conda-forge

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 include_directories(${XTENSOR_FFTW_INCLUDE_DIR})
 
 # .. xtl
-set(xtl_REQUIRED_VERSION 0.6.9)
+set(xtl_REQUIRED_VERSION 0.8.0)
 if(TARGET xtl)
     set(xtl_VERSION ${XTL_VERSION_MAJOR}.${XTL_VERSION_MINOR}.${XTL_VERSION_PATCH})
     # Note: This is not SEMVER compatible comparison
@@ -111,7 +111,7 @@ else()
 endif()
 
 # .. xtensor
-set(xtensor_REQUIRED_VERSION 0.20.9)
+set(xtensor_REQUIRED_VERSION 0.26.0)
 if(TARGET xtensor)
     set(xtensor_VERSION ${XTENSOR_VERSION_MAJOR}.${XTENSOR_VERSION_MINOR}.${XTENSOR_VERSION_PATCH})
     # Note: This is not SEMVER compatible comparison

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # - Copyright 2017 Johan Mabille (rpath fix)
 #
 
-cmake_minimum_required(VERSION 3.1.3)  # 3.1.3 for set(CMAKE_CXX_STANDARD 14)
+cmake_minimum_required(VERSION 3.29)  # 3.1.3 for set(CMAKE_CXX_STANDARD 14)
 
 project(xtensor-fftw)
 
@@ -86,7 +86,7 @@ endif()
 #--------------------------------------- build parameters for all targets
 # c++ standard build options
 # N.B.: these have to be set before defining targets!
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # - Copyright 2017 Johan Mabille (rpath fix)
 #
 
-cmake_minimum_required(VERSION 3.29)  # 3.1.3 for set(CMAKE_CXX_STANDARD 14)
+cmake_minimum_required(VERSION 3.29) 
 
 project(xtensor-fftw)
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 ############################################################################
 
-cmake_minimum_required(VERSION 3.29)  # 3.1.3 for set(CMAKE_CXX_STANDARD 14)
+cmake_minimum_required(VERSION 3.29)
 
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xtensor-fftw-bench)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 ############################################################################
 
-cmake_minimum_required(VERSION 3.1.3)  # 3.1.3 for set(CMAKE_CXX_STANDARD 14)
+cmake_minimum_required(VERSION 3.29)  # 3.1.3 for set(CMAKE_CXX_STANDARD 14)
 
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xtensor-fftw-bench)
@@ -32,7 +32,7 @@ include(CheckCXXCompilerFlag)
 
 #string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 20)
 
 #if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Intel")
 #    add_compile_options(-march=native) #-Wunused-parameter -Wextra -Wreorder -Wconversion)

--- a/bench/copyGBench.cmake.in
+++ b/bench/copyGBench.cmake.in
@@ -11,7 +11,7 @@
 #
 ############################################################################
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.29)
 
 project(googlebench-download NONE)
 

--- a/bench/downloadGBench.cmake.in
+++ b/bench/downloadGBench.cmake.in
@@ -11,7 +11,7 @@
 #
 ############################################################################
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.29)
 
 project(googlebench-download NONE)
 

--- a/include/xtensor-fftw/common.hpp
+++ b/include/xtensor-fftw/common.hpp
@@ -14,10 +14,9 @@
 #ifndef XTENSOR_FFTW_COMMON_HPP
 #define XTENSOR_FFTW_COMMON_HPP
 
-#include <xtensor/xarray.hpp>
-#include "xtensor/xcomplex.hpp"
-#include "xtensor/xeval.hpp"
-#include <xtl/xcomplex.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/core/xeval.hpp>
+#include <xtensor/misc/xcomplex.hpp>
 #include <complex>
 #include <tuple>
 #include <type_traits>

--- a/include/xtensor-fftw/helper.hpp
+++ b/include/xtensor-fftw/helper.hpp
@@ -12,7 +12,7 @@
 #define _USE_MATH_DEFINES  // for MSVC ("Math Constants are not defined in Standard C/C++")
 #include <cmath>           // M_PI
 
-#include <xtensor/xarray.hpp>
+#include <xtensor/containers/xarray.hpp>
 
 namespace xt {
   namespace fftw {

--- a/notebooks/intensely_edgy_cat.ipynb
+++ b/notebooks/intensely_edgy_cat.ipynb
@@ -9,13 +9,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#include <xtensor/xarray.hpp>    // xarrays!\n",
-    "#include <xtensor/xview.hpp>     // slice the image arrays into color channels\n",
-    "#include <xtensor/xbuilder.hpp>  // xt::stack\n",
+    "#include <xtensor/containers/xarray.hpp>    // xarrays!\n",
+    "#include <xtensor/views/xview.hpp>     // slice the image arrays into color channels\n",
+    "#include <xtensor/generators/xbuilder.hpp>  // xt::stack\n",
     "\n",
     "#include <xtensor-io/ximage.hpp> // for loading images\n",
     "\n",

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 ############################################################################
 
-cmake_minimum_required(VERSION 3.1.3)  # 3.1.3 for set(CMAKE_CXX_STANDARD 14)
+cmake_minimum_required(VERSION 3.29)  # 3.1.3 for set(CMAKE_CXX_STANDARD 14)
 
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xtensor-fftw-test)
@@ -31,7 +31,7 @@ include(CheckCXXCompilerFlag)
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 20)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR (CMAKE_CXX_COMPILER_ID MATCHES "Intel" AND NOT WIN32))
     if (DISABLE_EXCEPTIONS)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 ############################################################################
 
-cmake_minimum_required(VERSION 3.29)  # 3.1.3 for set(CMAKE_CXX_STANDARD 14)
+cmake_minimum_required(VERSION 3.29)
 
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xtensor-fftw-test)

--- a/test/basic_interface.hpp
+++ b/test/basic_interface.hpp
@@ -15,10 +15,10 @@
 #include <array>
 
 #include <stdexcept> // workaround for xt bug, where only including xarray does not include stdexcept; TODO: remove this include when bug is fixed!
-#include <xtensor/xarray.hpp>
-#include <xtensor/xio.hpp>
-#include <xtensor/xrandom.hpp>
-#include <xtensor/xcomplex.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/io/xio.hpp>
+#include <xtensor/generators/xrandom.hpp>
+#include <xtensor/misc/xcomplex.hpp>
 
 #include "gtest/gtest.h"
 

--- a/test/basic_interface_fft.cpp
+++ b/test/basic_interface_fft.cpp
@@ -18,7 +18,7 @@
 template <typename T>
 class TransformAndInvert_FFT : public ::testing::Test {};
 
-TYPED_TEST_CASE(TransformAndInvert_FFT, MyTypes);
+TYPED_TEST_SUITE(TransformAndInvert_FFT, MyTypes);
 
 ///////////////////////////////////////////////////////////////////////////////
 // Regular FFT (complex to complex)

--- a/test/basic_interface_hfft.cpp
+++ b/test/basic_interface_hfft.cpp
@@ -18,7 +18,7 @@
 template <typename T>
 class TransformAndInvert_hermFFT : public ::testing::Test {};
 
-TYPED_TEST_CASE(TransformAndInvert_hermFFT, MyTypes);
+TYPED_TEST_SUITE(TransformAndInvert_hermFFT, MyTypes);
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/basic_interface_rfft.cpp
+++ b/test/basic_interface_rfft.cpp
@@ -18,7 +18,7 @@
 template <typename T>
 class TransformAndInvert_realFFT : public ::testing::Test {};
 
-TYPED_TEST_CASE(TransformAndInvert_realFFT, MyTypes);
+TYPED_TEST_SUITE(TransformAndInvert_realFFT, MyTypes);
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/copyGTest.cmake.in
+++ b/test/copyGTest.cmake.in
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.29)
 
 project(googletest-download NONE)
 

--- a/test/downloadGTest.cmake.in
+++ b/test/downloadGTest.cmake.in
@@ -6,14 +6,16 @@
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.29)
 
 project(googletest-download NONE)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
     GIT_REPOSITORY    https://github.com/google/googletest.git
-    GIT_TAG           release-1.8.0
+    GIT_TAG           v1.16.0
     SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
     BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
     CONFIGURE_COMMAND ""
@@ -22,3 +24,5 @@ ExternalProject_Add(googletest
     TEST_COMMAND      ""
 )
 
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/test/examples.cpp
+++ b/test/examples.cpp
@@ -14,10 +14,10 @@
 
 #include <xtensor-fftw/basic_double.hpp>
 #include <xtensor-fftw/helper.hpp>
-#include <xtensor/xarray.hpp>
-#include <xtensor/xbuilder.hpp>  // xt::arange
-#include <xtensor/xmath.hpp>  // xt::sin, cos
-#include <xtensor/xio.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/generators/xbuilder.hpp>  // xt::arange
+#include <xtensor/core/xmath.hpp>  // xt::sin, cos
+#include <xtensor/io/xio.hpp>
 
 #include "gtest/gtest.h"
 

--- a/test/helper.cpp
+++ b/test/helper.cpp
@@ -9,7 +9,7 @@
 #define _USE_MATH_DEFINES  // for MSVC ("Math Constants are not defined in Standard C/C++")
 #include <cmath>           // M_PI
 
-#include <xtensor/xarray.hpp>
+#include <xtensor/containers/xarray.hpp>
 #include <xtensor-fftw/helper.hpp>
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
## 1. Summary
Adds compatibility with **xtensor 0.26** and refreshes the project’s build tool-chain.

## 2. Changes introduced
- **Bump xtensor requirement → 0.26.\***  
- **Increase minimum CMake version** to 3.29  
- **Update GoogleTest** to v1.16.0
- Adjust include directives and type aliases affected by the xtensor upgrade  
- Regenerate `CMakeLists.txt` cache and ensure CI builds use the new versions

## 3. Motivation & context
xtensor-fftw had fallen a release behind xtensor, causing build failures for downstream projects already on 0.26. Up-to-date tool-chain versions (CMake / GoogleTest) remove deprecated macros, improve diagnostics, and make it easier to compile on modern compilers.

## 4. Implementation notes
- Replaced new headers, e.g. `<xtensor/xarray.hpp>` -> `<xtensor/containers/xarray.hpp>`
- By default using C++20  
- Replace gtest `TYPED_TEST_SUITE` `TYPED_TEST_CASE`

## 5. Backward compatibility
| Component        | Status      | Notes                        |
|------------------|-------------|------------------------------|
| xtensor < 0.26    | **Dropped** | Requires 0.26 or newer       |

## 6. Testing
- `ctest` passes locally on Linux (GCC 11 / Clang 20)
- with latest `fftw3` 3.3.8

PS: apparently a lot of xtensor doc still use old headers...
PPS: I didn't change xtensor-io in the notebook, since that package isn't updated as well

